### PR TITLE
Bug Fix: no longer only captures one version of a location's coordinates

### DIFF
--- a/examples/example_workcell.yaml
+++ b/examples/example_workcell.yaml
@@ -29,3 +29,5 @@ modules:
 locations:
   webcam:
     webcam.pos: [0, 0, 0, 0, 0, 0]
+  workcell:
+    webcam.pos: [15, 0, 0, 0, 0, 0]

--- a/examples/example_workcell_docker.yaml
+++ b/examples/example_workcell_docker.yaml
@@ -24,8 +24,10 @@ modules:
     config:
       rest_node_address: "http://webcam_node:2001"
       rest_node_auth: ""
-    workcell_coordinates: [15, 0, 0, 0, 0, 0]
+    workcell_coordinates: [10, 0, 0, 0, 0, 0]
 
 locations:
   webcam:
-    webcam.pos: [0, 0, 0, 0, 0, 0]
+    webcam.pos: 0
+  workcell:
+    webcam.pos: [15, 0, 0, 0, 0, 0]

--- a/tests/manual_test/run_manual_test.py
+++ b/tests/manual_test/run_manual_test.py
@@ -14,7 +14,7 @@ def main():
     exp.register_exp()
     # This runs the simulated_workflow a simulated workflow
     flow_info_1 = exp.start_run(wf_path.resolve(), simulate=False, blocking=False)
-    #flow_info_2 = exp.start_run(wf_path.resolve(), simulate=False, blocking=False)
+    # flow_info_2 = exp.start_run(wf_path.resolve(), simulate=False, blocking=False)
     # This checks the state of the flows in the queue
     flows = exp.await_runs([flow_info_1["run_id"]])
     # This will print out the queued job

--- a/wei/core/data_classes.py
+++ b/wei/core/data_classes.py
@@ -314,7 +314,7 @@ class Location(BaseModel):
 
     name: str
     """Name of the location"""
-    workcell_coordinates: Any
+    coordinates: Any
     """Coordinates of the location"""
     state: Optional[str] = "Empty"
     """State of the location"""

--- a/wei/core/data_classes.py
+++ b/wei/core/data_classes.py
@@ -314,7 +314,7 @@ class Location(BaseModel):
 
     name: str
     """Name of the location"""
-    coordinates: Any
+    coordinates: Dict[str, Any]
     """Coordinates of the location"""
     state: Optional[str] = "Empty"
     """State of the location"""

--- a/wei/core/workflow.py
+++ b/wei/core/workflow.py
@@ -129,8 +129,7 @@ class WorkflowRunner:
         # Start executing the steps
         steps = []
         for module in self.workflow.modules:
-            if not(workcell.find_step_module(module.name)):
-              
+            if not (workcell.find_step_module(module.name)):
                 raise ValueError(
                     f"Module {module} not in Workcell {self.workflow.modules}"
                 )
@@ -145,11 +144,9 @@ class WorkflowRunner:
             valid = False
             for module in self.workflow.modules:
                 if step.module == module.name:
-                    valid = True 
-            if not(valid):
-                raise ValueError(
-                    f"Module {step.module} not in flow modules"
-                )
+                    valid = True
+            if not (valid):
+                raise ValueError(f"Module {step.module} not in flow modules")
             # replace position names with actual positions
             if (
                 isinstance(step.args, dict)

--- a/wei/scheduler.py
+++ b/wei/scheduler.py
@@ -175,15 +175,20 @@ class Scheduler:
                 for location, coordinates in self.workcell.locations[
                     module_name
                 ].items():
-                    self.state.set_location(
-                        location,
-                        Location(
-                            name=location,
-                            workcell_coordinates=coordinates,
-                            state="Empty",
-                            queue=[],
-                        ),
-                    )
+                    try:
+                        self.state.get_location(location)
+                        location.coordinates[module_name] = coordinates
+                        self.state.set_location()
+                    except KeyError:
+                        self.state.set_location(
+                            location,
+                            Location(
+                                name=location,
+                                coordinates={module_name: coordinates},
+                                state="Empty",
+                                queue=[],
+                            ),
+                        )
         print("Starting Process")
         while True:
             with self.state.state_lock():  # * Lock the state for the duration of the update loop

--- a/wei/scheduler.py
+++ b/wei/scheduler.py
@@ -172,18 +172,18 @@ class Scheduler:
                 module.state = ModuleStatus.INIT
                 self.state.set_module(module.name, module)
             for module_name in self.workcell.locations:
-                for location, coordinates in self.workcell.locations[
+                for location_name, coordinates in self.workcell.locations[
                     module_name
                 ].items():
                     try:
-                        self.state.get_location(location)
+                        location = self.state.get_location(location_name)
                         location.coordinates[module_name] = coordinates
-                        self.state.set_location()
+                        self.state.set_location(location_name, location)
                     except KeyError:
                         self.state.set_location(
-                            location,
+                            location_name,
                             Location(
-                                name=location,
+                                name=location_name,
                                 coordinates={module_name: coordinates},
                                 state="Empty",
                                 queue=[],


### PR DESCRIPTION
Had a bug where we were only loading one set of coordinates into the state manager's representation of the locations.