### PR TITLE
Allow server to run sans Dashboard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ad_sdl.wei"
-version = "0.7.0"
+version = "0.7.1"
 description = "The Rapid Prototyping Laboratory's Workflow Execution Interface."
 authors = [
     {name = "Rafael Vescovi", email = "ravescovi@anl.gov"},

--- a/src/wei/server.py
+++ b/src/wei/server.py
@@ -1,6 +1,7 @@
 """The server that takes incoming WEI flow requests from the experiment application"""
 
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Dict
 
 from fastapi import FastAPI
@@ -49,7 +50,9 @@ async def lifespan(app: FastAPI) -> None:  # type: ignore[misc]
     app.include_router(module_routes.router, prefix="/modules")
     app.include_router(workcell_routes.router, prefix="/workcells")
     app.include_router(workcell_routes.router, prefix="/wc")
-    app.mount("/", StaticFiles(directory="wei/src/ui/dist", html=True))
+    ui_files_path = Path("wei") / "src" / "ui" / "dist"
+    if ui_files_path.exists():
+        app.mount("/", StaticFiles(directory=ui_files_path, html=True))
     EventHandler.initialize_diaspora()
 
     if Config.autostart_engine:


### PR DESCRIPTION
- Two line fix to allow the WEI server to run even if the dashboard hasn't been built